### PR TITLE
feat: enhance transaction categorization and insights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "lucide-react": "^0.316.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "string-similarity": "^4.0.4"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.4",
@@ -3421,6 +3422,13 @@
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-similarity": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz",
+      "integrity": "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "ISC"
     },
     "node_modules/string-width": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "lucide-react": "^0.316.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "string-similarity": "^4.0.4"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.4",

--- a/src/components/InsightsTab.jsx
+++ b/src/components/InsightsTab.jsx
@@ -1,15 +1,22 @@
 import React from 'react';
 import { FileText, PieChart } from 'lucide-react';
-import { getSpendingByCategory } from '../utils/transactions';
+import { getSpendingByCategory, identifyRecurringTransactions, detectSpendingTrends } from '../utils/transactions';
 
-const InsightsTab = ({ transactions }) => (
-  transactions.length === 0 ? (
-    <div className="text-center">
-      <FileText className="h-16 w-16 text-gray-400 mx-auto mb-4" />
-      <h3 className="text-xl font-semibold mb-4">No Data Available</h3>
-      <p className="text-gray-600">Upload your transaction data to see personalized insights.</p>
-    </div>
-  ) : (
+const InsightsTab = ({ transactions }) => {
+  if (transactions.length === 0) {
+    return (
+      <div className="text-center">
+        <FileText className="h-16 w-16 text-gray-400 mx-auto mb-4" />
+        <h3 className="text-xl font-semibold mb-4">No Data Available</h3>
+        <p className="text-gray-600">Upload your transaction data to see personalized insights.</p>
+      </div>
+    );
+  }
+
+  const recurring = identifyRecurringTransactions(transactions);
+  const trends = detectSpendingTrends(transactions);
+
+  return (
     <div className="space-y-6">
       <div className="bg-gradient-to-r from-blue-500 to-purple-600 text-white p-6 rounded-lg">
         <h3 className="text-xl font-semibold mb-4">Financial Overview</h3>
@@ -59,8 +66,44 @@ const InsightsTab = ({ transactions }) => (
           </div>
         </div>
       </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="bg-gray-50 p-6 rounded-lg">
+          <h4 className="text-lg font-semibold mb-4">Spending Trends</h4>
+          <div className="space-y-3 text-sm">
+            {trends.length === 0 ? (
+              <p className="text-gray-600">Not enough data to determine trends.</p>
+            ) : (
+              trends.map(t => (
+                <div key={t.category} className="flex justify-between items-center">
+                  <span className="font-medium">{t.category}</span>
+                  <span className={t.direction === 'up' ? 'text-red-600' : 'text-green-600'}>
+                    {t.direction === 'up' ? '+' : '-'}${Math.abs(t.change).toFixed(2)}
+                  </span>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="bg-gray-50 p-6 rounded-lg">
+          <h4 className="text-lg font-semibold mb-4">Recurring Transactions</h4>
+          <div className="space-y-3 text-sm">
+            {recurring.length === 0 ? (
+              <p className="text-gray-600">No recurring transactions detected.</p>
+            ) : (
+              recurring.map(r => (
+                <div key={r.description} className="flex justify-between items-center">
+                  <span className="font-medium">{r.description}</span>
+                  <span className="text-gray-600">${r.averageAmount.toFixed(2)}</span>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
     </div>
-  )
-);
+  );
+};
 
 export default InsightsTab;

--- a/src/utils/transactions.js
+++ b/src/utils/transactions.js
@@ -1,3 +1,5 @@
+import stringSimilarity from 'string-similarity';
+
 export const parseCSV = (csvText) => {
   const lines = csvText.split('\n').filter(line => line.trim());
   if (lines.length < 2) return [];
@@ -32,6 +34,18 @@ export const parseCSV = (csvText) => {
   return transactions.filter(t => t.description && t.amount !== 0);
 };
 
+const samplePatterns = {
+  'Groceries': ['whole foods market', 'kroger', 'trader joe', 'supermarket', 'grocery'],
+  'Transportation': ['uber', 'lyft', 'shell', 'exxon', 'bp', 'gas station'],
+  'Dining Out': ['restaurant', 'dining', 'coffee shop', 'pizza hut', 'burger king'],
+  'Subscriptions': ['netflix', 'spotify', 'hulu', 'amazon prime', 'subscription'],
+  'Utilities': ['comcast', 'verizon', 'electric company', 'water bill', 'internet'],
+  'Housing': ['rent', 'mortgage payment', 'landlord'],
+  'Shopping': ['walmart', 'target', 'amazon order', 'mall'],
+  'Healthcare': ['pharmacy', 'walgreens', 'cvs', 'doctor', 'hospital'],
+  'Fitness': ['gym', 'fitness', 'yoga', 'workout']
+};
+
 export const categorizeTransaction = (description) => {
   const desc = description.toLowerCase();
 
@@ -45,7 +59,17 @@ export const categorizeTransaction = (description) => {
   if (desc.includes('medical') || desc.includes('pharmacy') || desc.includes('doctor')) return 'Healthcare';
   if (desc.includes('gym') || desc.includes('fitness')) return 'Fitness';
 
-  return 'Other';
+  let bestCategory = 'Other';
+  let highestRating = 0;
+  Object.entries(samplePatterns).forEach(([category, samples]) => {
+    const match = stringSimilarity.findBestMatch(desc, samples);
+    if (match.bestMatch.rating > highestRating) {
+      highestRating = match.bestMatch.rating;
+      bestCategory = category;
+    }
+  });
+
+  return highestRating > 0.3 ? bestCategory : 'Other';
 };
 
 export const getSpendingByCategory = (transactions) => {
@@ -57,6 +81,53 @@ export const getSpendingByCategory = (transactions) => {
     .sort((a, b) => b[1] - a[1])
     .slice(0, 6)
     .map(([category, amount]) => ({ category, amount }));
+};
+
+export const identifyRecurringTransactions = (transactions) => {
+  const map = {};
+  transactions.forEach(t => {
+    const key = t.description.toLowerCase();
+    const month = t.date.slice(0, 7);
+    if (!map[key]) map[key] = { description: t.description, amounts: [], months: new Set() };
+    map[key].amounts.push(Math.abs(t.amount));
+    map[key].months.add(month);
+  });
+  return Object.values(map)
+    .filter(r => r.months.size >= 3)
+    .map(r => ({
+      description: r.description,
+      averageAmount: r.amounts.reduce((a, b) => a + b, 0) / r.amounts.length,
+      occurrences: r.amounts.length
+    }))
+    .sort((a, b) => b.occurrences - a.occurrences)
+    .slice(0, 5);
+};
+
+export const detectSpendingTrends = (transactions) => {
+  const byMonth = {};
+  transactions.forEach(t => {
+    const month = t.date.slice(0, 7);
+    byMonth[month] = byMonth[month] || {};
+    byMonth[month][t.category] = (byMonth[month][t.category] || 0) + Math.abs(t.amount);
+  });
+
+  const months = Object.keys(byMonth).sort();
+  if (months.length < 2) return [];
+  const latest = months[months.length - 1];
+  const prev = months[months.length - 2];
+  const categories = new Set([...Object.keys(byMonth[latest] || {}), ...Object.keys(byMonth[prev] || {})]);
+
+  const trends = [];
+  categories.forEach(cat => {
+    const current = byMonth[latest][cat] || 0;
+    const previous = byMonth[prev][cat] || 0;
+    const change = current - previous;
+    if (change !== 0) {
+      trends.push({ category: cat, change, direction: change > 0 ? 'up' : 'down' });
+    }
+  });
+
+  return trends.sort((a, b) => Math.abs(b.change) - Math.abs(a.change)).slice(0, 5);
 };
 
 export const generateInsights = (transactions) => {
@@ -75,7 +146,12 @@ export const generateInsights = (transactions) => {
   const topCategory = Object.entries(categories).sort((a, b) => b[1] - a[1])[0];
   const avgMonthly = Object.values(monthlySpending).reduce((a, b) => a + b, 0) / Object.keys(monthlySpending).length;
 
-  return `Based on your transaction history:
+  const recurring = identifyRecurringTransactions(transactions);
+  const trends = detectSpendingTrends(transactions);
+  const increasing = trends.filter(t => t.direction === 'up').map(t => t.category);
+  const decreasing = trends.filter(t => t.direction === 'down').map(t => t.category);
+
+  let summary = `Based on your transaction history:
 
 💰 Total Spending: $${totalSpent.toFixed(2)}
 📊 Top Category: ${topCategory[0]} ($${topCategory[1].toFixed(2)})
@@ -85,4 +161,16 @@ Key Insights:
 • You spend most on ${topCategory[0].toLowerCase()}
 • ${Object.keys(categories).length} different spending categories identified
 • ${transactions.length} transactions analyzed`;
+
+  if (recurring.length > 0) {
+    summary += `\n• Recurring payments: ${recurring.map(r => r.description).slice(0,3).join(', ')}`;
+  }
+  if (increasing.length > 0) {
+    summary += `\n• Spending increasing in: ${increasing.join(', ')}`;
+  }
+  if (decreasing.length > 0) {
+    summary += `\n• Spending decreasing in: ${decreasing.join(', ')}`;
+  }
+
+  return summary;
 };

--- a/src/utils/transactions.test.js
+++ b/src/utils/transactions.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { categorizeTransaction, identifyRecurringTransactions, detectSpendingTrends } from './transactions';
+
+describe('categorizeTransaction', () => {
+  it('classifies using keyword matching', () => {
+    expect(categorizeTransaction('Walmart Supercenter')).toBe('Shopping');
+  });
+
+  it('classifies using pattern recognition', () => {
+    expect(categorizeTransaction('Whole Foods Market')).toBe('Groceries');
+  });
+});
+
+describe('identifyRecurringTransactions', () => {
+  it('detects recurring payments', () => {
+    const data = [
+      { date: '2024-01-01', description: 'Spotify', amount: -9.99, category: 'Subscriptions' },
+      { date: '2024-02-01', description: 'Spotify', amount: -9.99, category: 'Subscriptions' },
+      { date: '2024-03-01', description: 'Spotify', amount: -9.99, category: 'Subscriptions' },
+    ];
+    const recurring = identifyRecurringTransactions(data);
+    expect(recurring.length).toBe(1);
+    expect(recurring[0].description).toBe('Spotify');
+  });
+});
+
+describe('detectSpendingTrends', () => {
+  it('finds increasing spend in categories', () => {
+    const data = [
+      { date: '2024-01-10', description: 'Cafe', amount: -10, category: 'Dining Out' },
+      { date: '2024-02-10', description: 'Cafe', amount: -20, category: 'Dining Out' },
+    ];
+    const trends = detectSpendingTrends(data);
+    expect(trends.length).toBeGreaterThan(0);
+    expect(trends[0].category).toBe('Dining Out');
+    expect(trends[0].direction).toBe('up');
+  });
+});


### PR DESCRIPTION
## Summary
- use keyword and pattern matching to better categorize transactions and reduce "Other"
- detect recurring payments and category spending trends
- surface trends and recurring transactions in the insights dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fc7e1ae94832fb431b8c088efe99f