### PR TITLE
Remove API key configured label

### DIFF
--- a/src/FinancialAdvisor.jsx
+++ b/src/FinancialAdvisor.jsx
@@ -304,16 +304,6 @@ Keep response under 100 words and be encouraging but realistic.`
             </div>
           )}
           
-          {/* Show status if using environment key */}
-          {hasEnvApiKey && (
-            <div className="mt-6 max-w-md mx-auto">
-              <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-center">
-                <p className="text-sm text-green-700">
-                  ✓ API key configured - All features enabled
-                </p>
-              </div>
-            </div>
-          )}
         </div>
 
         <div className="flex flex-wrap justify-center mb-8 bg-white rounded-lg shadow-md p-2">


### PR DESCRIPTION
## Summary
- remove redundant status banner for API key configuration in FinancialAdvisor UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fdd21db50832fb145fadd79d67d69