### PR TITLE
Allow reopening onboarding from main menu

### DIFF
--- a/src/FinancialAdvisor.jsx
+++ b/src/FinancialAdvisor.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Upload, MessageCircle, DollarSign, TrendingUp, Shield, BarChart3 } from 'lucide-react';
+import { Upload, MessageCircle, DollarSign, TrendingUp, Shield, BarChart3, User } from 'lucide-react';
 import UploadTab from './components/UploadTab';
 import ChatTab from './components/ChatTab';
 import PurchaseAdvisorTab from './components/PurchaseAdvisorTab';
@@ -257,6 +257,7 @@ Keep response under 100 words and be encouraging but realistic.`
         <OnboardingModal
           onComplete={handleOnboardingComplete}
           setTransactions={setTransactions}
+          initialData={userProfile}
         />
       )}
       <div className="container mx-auto px-4 py-8 max-w-6xl">
@@ -311,11 +312,12 @@ Keep response under 100 words and be encouraging but realistic.`
             { id: 'upload', label: 'Upload Data', icon: Upload },
             { id: 'chat', label: 'Financial Chat', icon: MessageCircle },
             { id: 'purchase', label: 'Purchase Advisor', icon: DollarSign },
-            { id: 'insights', label: 'Insights', icon: BarChart3 }
+            { id: 'insights', label: 'Insights', icon: BarChart3 },
+            { id: 'onboarding', label: 'Onboarding', icon: User }
           ].map(({ id, label, icon: Icon }) => (
             <button
               key={id}
-              onClick={() => setActiveTab(id)}
+              onClick={() => id === 'onboarding' ? setShowOnboarding(true) : setActiveTab(id)}
               className={`flex items-center px-4 py-2 rounded-md mx-1 my-1 transition-colors ${
                 activeTab === id
                   ? 'bg-blue-600 text-white'

--- a/src/components/OnboardingModal.jsx
+++ b/src/components/OnboardingModal.jsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import { parseCSV } from '../utils/transactions';
 
-const OnboardingModal = ({ onComplete, setTransactions }) => {
-  const [taxFileName, setTaxFileName] = useState('');
+const OnboardingModal = ({ onComplete, setTransactions, initialData = {} }) => {
+  const [taxFileName, setTaxFileName] = useState(initialData.taxReturn || '');
   const [transactionFileName, setTransactionFileName] = useState('');
-  const [name, setName] = useState('');
-  const [goals, setGoals] = useState('');
-  const [questions, setQuestions] = useState('');
+  const [name, setName] = useState(initialData.name || '');
+  const [goals, setGoals] = useState(initialData.goals || '');
+  const [questions, setQuestions] = useState(initialData.questions || '');
 
   const handleTaxUpload = (e) => {
     const file = e.target.files[0];
@@ -91,7 +91,7 @@ const OnboardingModal = ({ onComplete, setTransactions }) => {
             onClick={() => onComplete({})}
             className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
           >
-            Skip for now
+            Close
           </button>
           <button
             type="submit"

--- a/src/components/OnboardingModal.test.jsx
+++ b/src/components/OnboardingModal.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import OnboardingModal from './OnboardingModal';
+
+describe('OnboardingModal', () => {
+  it('prefills form fields from initialData', () => {
+    render(
+      <OnboardingModal
+        onComplete={() => {}}
+        setTransactions={() => {}}
+        initialData={{
+          name: 'Alice',
+          goals: 'Save more',
+          questions: 'What is a 401k?',
+          taxReturn: 'tax.pdf'
+        }}
+      />
+    );
+
+    expect(screen.getByDisplayValue('Alice')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Save more')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('What is a 401k?')).toBeInTheDocument();
+    expect(screen.getByText(/Selected: tax.pdf/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add onboarding button to navigation to reopen onboarding modal
- Prefill onboarding form with saved profile information
- Add test covering onboarding modal prefill

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fe19f4404832fb19159358447ccec